### PR TITLE
Homepage implementation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,13 +3,13 @@
 </script>
 
 <template>
-  <p>
-    <strong>Current route path:</strong> {{ $route.fullPath }}
-  </p>
-  <nav>
-    <RouterLink to="/">Go to Home</RouterLink>
-    <RouterLink to="/release/1">Go to Release</RouterLink>
-  </nav>
+<!--  <p>-->
+<!--    <strong>Current route path:</strong> {{ $route.fullPath }}-->
+<!--  </p>-->
+<!--  <nav>-->
+<!--    <RouterLink to="/">Go to Home</RouterLink>-->
+<!--    <RouterLink to="/release/1">Go to Release</RouterLink>-->
+<!--  </nav>-->
   <main>
     <RouterView />
   </main>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,15 +2,106 @@
   <div>
     <h1>Welcome to KollektivXplorer</h1>
     <p>Explore releases</p>
-    <!-- Add a list of releases here later -->
+
     <v-container>
-      <v-text-field v-model="msg" />
+      <v-data-table-virtual
+          :headers="headers"
+          :items="KollektivXReleases"
+          height="750"
+          width="auto"
+          item-value="name"
+      >
+        <template v-slot:item.image="{ item }">
+          <a
+              :href="item.uri"
+              target="_blank"
+          >
+            <img :src="item.thumb" alt="Cover">
+          </a>
+        </template>
+
+        <template v-slot:item.artists="{ item }">
+          <span>
+            <a
+                v-for="(artist, index) in item.artists"
+                :key="artist.id"
+                :href="`https://www.discogs.com/artist/${artist.id}`"
+                target="_blank"
+            >
+              {{ artist.name }}
+              <template v-if="index !== item.artists.length - 1 && item.artists.length > 1"> , </template>
+            </a>
+          </span>
+        </template>
+
+        <template v-slot:item.title="{ item }">
+          <span>
+            <a
+                :href="item.uri"
+                target="_blank"
+            >
+              {{ item.title }}
+            </a>
+          </span>
+        </template>
+
+        <template v-slot:item.labels="{ item }">
+          <span>
+            <a
+                v-for="(label, index) in item.labels"
+                :key="label.id"
+                :href="`https://www.discogs.com/label/${label.id}`"
+                target="_blank"
+            >
+              {{ label.name }}
+              <template v-if="index !== item.labels.length - 1 && item.labels.length > 1"> , </template>
+            </a>
+          </span>
+        </template>
+
+        <template v-slot:item.formats="{ item }">
+          <span>
+            <template v-for="(format, index) in item.formats" :key="index">
+              {{ format.name }},
+              <template v-if="format.descriptions && format.descriptions.length">
+                {{ format.descriptions.join(', ') }}
+              </template>
+              <template v-if="index !== item.formats.length - 1"> , </template>
+            </template>
+          </span>
+        </template>
+
+        <template v-slot:item.genres="{ item }">
+          <span>
+            {{ item.genres.join(', ') }}
+          </span>
+        </template>
+
+        <template v-slot:item.styles="{ item }">
+          <span>
+            {{ item.styles.join(', ') }}
+          </span>
+        </template>
+
+      </v-data-table-virtual>
     </v-container>
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue'
+import KollektivXReleases from '/src/assets/KollektivXData.json';
 
-const msg = ref('Hello World!')
+const headers = ref([
+  { title: 'Cover', key: 'image', sortable: false },
+  { title: 'Artists', key: 'artists' },
+  { title: 'Title', key: 'title' },
+  { title: 'Labels', key: 'labels' },
+  { title: 'Formats', key: 'formats' },
+  { title: 'Country', key: 'country' },
+  { title: 'Released', key: 'released' },
+  { title: 'Genres', key: 'genres' },
+  { title: 'Styles', key: 'styles' },
+  { title: 'Actions', key: 'actions', sortable: false },
+]);
 </script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,12 +1,24 @@
 <template>
   <div>
     <h1>Welcome to KollektivXplorer</h1>
-    <p>Explore releases</p>
 
-    <v-container>
-      <v-data-table-virtual
+    <v-card flat>
+      <template v-slot:text>
+        <v-text-field
+            v-model="search"
+            label="Search"
+            prepend-inner-icon="mdi-magnify"
+            variant="outlined"
+            hide-details
+            single-line
+        ></v-text-field>
+      </template>
+
+      <v-data-table
+          :custom-filter="filterByFields"
           :headers="headers"
           :items="KollektivXReleases"
+          :search="search"
           height="750"
           width="auto"
           item-value="name"
@@ -82,9 +94,8 @@
             {{ item.styles.join(', ') }}
           </span>
         </template>
-
-      </v-data-table-virtual>
-    </v-container>
+      </v-data-table>
+    </v-card>
   </div>
 </template>
 
@@ -92,6 +103,7 @@
 import { ref } from 'vue'
 import KollektivXReleases from '/src/assets/KollektivXData.json';
 
+const search = ref('');
 const headers = ref([
   { title: 'Cover', key: 'image', sortable: false },
   { title: 'Artists', key: 'artists' },
@@ -104,4 +116,22 @@ const headers = ref([
   { title: 'Styles', key: 'styles' },
   { title: 'Actions', key: 'actions', sortable: false },
 ]);
+
+function filterByFields(value, query, item) {
+  if (!query) return true;
+  const normalizedQuery = query.toLowerCase();
+
+  if (typeof value === 'string') {
+    return value.toLowerCase().includes(normalizedQuery);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((val) =>
+        typeof val === 'string' && val.toLowerCase().includes(normalizedQuery) ||
+        typeof val === 'object' && val.name && val.name.toLowerCase().includes(normalizedQuery)
+    );
+  }
+
+  return false;
+}
 </script>


### PR DESCRIPTION
This pull request introduces the homepage for **KollektivXplorer**, showcasing all releases collected by KollektivX. The homepage features a data table (`v-data-table` from Vuetify), selected for its built-in pagination and filtering capabilities.

Users can easily search and filter through the data by various criteria, including artists, titles, labels, countries, genres, and styles, enhancing the overall user experience and making it more intuitive to explore the available releases.